### PR TITLE
[TASK] Add select renderType to Flexforms

### DIFF
--- a/Configuration/FlexForms/Continent.xml
+++ b/Configuration/FlexForms/Continent.xml
@@ -11,6 +11,7 @@
          <label>LLL:EXT:contexts_geolocation/Resources/Private/Language/flexform.xml:continent.field_continents</label>
          <config>
            <type>select</type>
+           <renderType>selectSingle</renderType>
            <items type="array">
             <numIndex index="0" type="array">
              <numIndex index="0">- unknown -</numIndex>

--- a/Configuration/FlexForms/Country.xml
+++ b/Configuration/FlexForms/Country.xml
@@ -11,6 +11,7 @@
          <label>LLL:EXT:contexts_geolocation/Resources/Private/Language/flexform.xml:country.field_countries</label>
          <config>
            <type>select</type>
+           <renderType>selectSingle</renderType>
            <size>10</size>
            <itemsProcFunc>Netresearch\ContextsGeolocation\Backend-&gt;getCountries</itemsProcFunc>
            <minitems>1</minitems>


### PR DESCRIPTION
This fixes the following deprecation message:

> FormEngine did an on-the-fly migration of a flex form data structure.
> This is deprecated and will be removed with TYPO3 CMS 8. Merge the
> following changes into the flex form definition of table
> "tx_contexts_contexts"" in field "type_conf"":Using select fields
> without the "renderType" setting is deprecated in table "dummyTable" and
> column "dummyField"