### PR TITLE
fix: CI improvements and functional test ApplicationType fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-01-28 -->
+<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-01-30 -->
 
 # AGENTS.md
 
@@ -66,7 +66,7 @@ Classes/                       # PHP source code
 │   ├── ContinentContext.php
 │   └── DistanceContext.php
 ├── Service/                   # Business logic services
-│   └── GeoIpService.php
+│   └── GeoLocationService.php
 ├── Exception/                 # Custom exceptions
 │   └── GeoIpException.php
 └── Dto/                       # Value objects for geolocation data

--- a/Classes/AGENTS.md
+++ b/Classes/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-01-28 -->
+<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-01-30 -->
 
 # AGENTS.md - Classes/
 
@@ -52,7 +52,7 @@ Prefer constructor injection via `Services.yaml`:
 
 ```php
 public function __construct(
-    private readonly GeoIpService $geoIpService,
+    private readonly GeoLocationService $geoIpService,
 ) {}
 ```
 
@@ -196,12 +196,12 @@ declare(strict_types=1);
 namespace Netresearch\ContextsGeolocation\Context\Type;
 
 use Netresearch\Contexts\Context\AbstractContext;
-use Netresearch\ContextsGeolocation\Service\GeoIpService;
+use Netresearch\ContextsGeolocation\Service\GeoLocationService;
 
 final class CountryContext extends AbstractContext
 {
     public function __construct(
-        private readonly GeoIpService $geoIpService,
+        private readonly GeoLocationService $geoIpService,
     ) {}
 
     public function match(array $arDependencies = []): bool
@@ -249,7 +249,7 @@ declare(strict_types=1);
 namespace Netresearch\ContextsGeolocation\Context\Type;
 
 use Netresearch\Contexts\Context\AbstractContext;
-use Netresearch\ContextsGeolocation\Service\GeoIpService;
+use Netresearch\ContextsGeolocation\Service\GeoLocationService;
 
 final class ContinentContext extends AbstractContext
 {
@@ -257,7 +257,7 @@ final class ContinentContext extends AbstractContext
     // EU (Europe), NA (North America), OC (Oceania), SA (South America)
 
     public function __construct(
-        private readonly GeoIpService $geoIpService,
+        private readonly GeoLocationService $geoIpService,
     ) {}
 
     public function match(array $arDependencies = []): bool
@@ -300,14 +300,14 @@ declare(strict_types=1);
 namespace Netresearch\ContextsGeolocation\Context\Type;
 
 use Netresearch\Contexts\Context\AbstractContext;
-use Netresearch\ContextsGeolocation\Service\GeoIpService;
+use Netresearch\ContextsGeolocation\Service\GeoLocationService;
 
 final class DistanceContext extends AbstractContext
 {
     private const EARTH_RADIUS_KM = 6371.0;
 
     public function __construct(
-        private readonly GeoIpService $geoIpService,
+        private readonly GeoLocationService $geoIpService,
     ) {}
 
     public function match(array $arDependencies = []): bool
@@ -388,7 +388,7 @@ use Netresearch\ContextsGeolocation\Dto\GeoLocation;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Http\ServerRequestFactory;
 
-final class GeoIpService
+final class GeoLocationService
 {
     public function __construct(
         private readonly GeoIpAdapterInterface $adapter,

--- a/Classes/Context/Type/AbstractGeolocationContext.php
+++ b/Classes/Context/Type/AbstractGeolocationContext.php
@@ -46,7 +46,9 @@ abstract class AbstractGeolocationContext extends AbstractContext
     {
         if ($this->geoLocationService === null) {
             // Use the DI container to get the properly configured service
-            $this->geoLocationService = GeneralUtility::getContainer()->get(GeoLocationService::class);
+            $service = GeneralUtility::getContainer()->get(GeoLocationService::class);
+            \assert($service instanceof GeoLocationService);
+            $this->geoLocationService = $service;
         }
 
         return $this->geoLocationService;

--- a/Classes/Context/Type/AbstractGeolocationContext.php
+++ b/Classes/Context/Type/AbstractGeolocationContext.php
@@ -14,6 +14,7 @@ namespace Netresearch\ContextsGeolocation\Context\Type;
 use Netresearch\Contexts\Context\AbstractContext;
 use Netresearch\ContextsGeolocation\Service\GeoLocationService;
 use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -53,7 +54,7 @@ abstract class AbstractGeolocationContext extends AbstractContext
                 $service = $container->get(GeoLocationService::class);
                 \assert($service instanceof GeoLocationService);
                 $this->geoLocationService = $service;
-            } catch (\Throwable) {
+            } catch (Throwable) {
                 // DI container not available or not properly initialized
                 // This can happen during functional tests when Container::matchAll()
                 // instantiates context types before the DI container is fully warmed up

--- a/Classes/Context/Type/AbstractGeolocationContext.php
+++ b/Classes/Context/Type/AbstractGeolocationContext.php
@@ -45,7 +45,8 @@ abstract class AbstractGeolocationContext extends AbstractContext
     protected function getGeoLocationService(): GeoLocationService
     {
         if ($this->geoLocationService === null) {
-            $this->geoLocationService = GeneralUtility::makeInstance(GeoLocationService::class);
+            // Use the DI container to get the properly configured service
+            $this->geoLocationService = GeneralUtility::getContainer()->get(GeoLocationService::class);
         }
 
         return $this->geoLocationService;

--- a/Classes/Context/Type/AbstractGeolocationContext.php
+++ b/Classes/Context/Type/AbstractGeolocationContext.php
@@ -14,6 +14,7 @@ namespace Netresearch\ContextsGeolocation\Context\Type;
 use Netresearch\Contexts\Context\AbstractContext;
 use Netresearch\ContextsGeolocation\Service\GeoLocationService;
 use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Abstract base class for geolocation context types.
@@ -24,7 +25,7 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 abstract class AbstractGeolocationContext extends AbstractContext
 {
-    protected GeoLocationService $geoLocationService;
+    protected ?GeoLocationService $geoLocationService = null;
 
     /**
      * @param array<string, mixed> $arRow Database context row
@@ -32,10 +33,22 @@ abstract class AbstractGeolocationContext extends AbstractContext
     public function __construct(array $arRow = [], ?GeoLocationService $geoLocationService = null)
     {
         parent::__construct($arRow);
+        $this->geoLocationService = $geoLocationService;
+    }
 
-        if ($geoLocationService !== null) {
-            $this->geoLocationService = $geoLocationService;
+    /**
+     * Get the GeoLocationService instance.
+     *
+     * Uses lazy initialization to support context creation by the Container
+     * which doesn't use TYPO3's DI container.
+     */
+    protected function getGeoLocationService(): GeoLocationService
+    {
+        if ($this->geoLocationService === null) {
+            $this->geoLocationService = GeneralUtility::makeInstance(GeoLocationService::class);
         }
+
+        return $this->geoLocationService;
     }
 
     /**
@@ -59,7 +72,7 @@ abstract class AbstractGeolocationContext extends AbstractContext
             return null;
         }
 
-        return $this->geoLocationService->getClientIpAddress($request);
+        return $this->getGeoLocationService()->getClientIpAddress($request);
     }
 
     /**
@@ -67,7 +80,7 @@ abstract class AbstractGeolocationContext extends AbstractContext
      */
     protected function isPrivateIp(string $ip): bool
     {
-        return $this->geoLocationService->isPrivateIp($ip);
+        return $this->getGeoLocationService()->isPrivateIp($ip);
     }
 
     /**

--- a/Classes/Context/Type/ContinentContext.php
+++ b/Classes/Context/Type/ContinentContext.php
@@ -97,7 +97,12 @@ class ContinentContext extends AbstractGeolocationContext
         }
 
         // Get continent code from GeoIP
-        $continentCode = $this->getGeoLocationService()->getLocationForIp($clientIp)?->continentCode;
+        $service = $this->getGeoLocationService();
+        if ($service === null) {
+            return $this->storeInSession($this->invert(false));
+        }
+
+        $continentCode = $service->getLocationForIp($clientIp)?->continentCode;
 
         if ($continentCode === null) {
             return $this->storeInSession($this->invert(false));

--- a/Classes/Context/Type/ContinentContext.php
+++ b/Classes/Context/Type/ContinentContext.php
@@ -97,7 +97,7 @@ class ContinentContext extends AbstractGeolocationContext
         }
 
         // Get continent code from GeoIP
-        $continentCode = $this->geoLocationService->getLocationForIp($clientIp)?->continentCode;
+        $continentCode = $this->getGeoLocationService()->getLocationForIp($clientIp)?->continentCode;
 
         if ($continentCode === null) {
             return $this->storeInSession($this->invert(false));

--- a/Classes/Context/Type/CountryContext.php
+++ b/Classes/Context/Type/CountryContext.php
@@ -72,7 +72,12 @@ class CountryContext extends AbstractGeolocationContext
         }
 
         // Get country code from GeoIP
-        $countryCode = $this->getGeoLocationService()->getLocationForIp($clientIp)?->countryCode;
+        $service = $this->getGeoLocationService();
+        if ($service === null) {
+            return $this->storeInSession($this->invert(false));
+        }
+
+        $countryCode = $service->getLocationForIp($clientIp)?->countryCode;
 
         if ($countryCode === null) {
             return $this->storeInSession($this->invert(false));

--- a/Classes/Context/Type/CountryContext.php
+++ b/Classes/Context/Type/CountryContext.php
@@ -72,7 +72,7 @@ class CountryContext extends AbstractGeolocationContext
         }
 
         // Get country code from GeoIP
-        $countryCode = $this->geoLocationService->getLocationForIp($clientIp)?->countryCode;
+        $countryCode = $this->getGeoLocationService()->getLocationForIp($clientIp)?->countryCode;
 
         if ($countryCode === null) {
             return $this->storeInSession($this->invert(false));

--- a/Classes/Context/Type/DistanceContext.php
+++ b/Classes/Context/Type/DistanceContext.php
@@ -80,7 +80,7 @@ class DistanceContext extends AbstractGeolocationContext
         }
 
         // Get visitor coordinates from GeoIP
-        $location = $this->geoLocationService->getLocationForIp($clientIp);
+        $location = $this->getGeoLocationService()->getLocationForIp($clientIp);
 
         if ($location === null || !$location->hasCoordinates()) {
             return $this->storeInSession($this->invert(false));

--- a/Classes/Context/Type/DistanceContext.php
+++ b/Classes/Context/Type/DistanceContext.php
@@ -80,7 +80,12 @@ class DistanceContext extends AbstractGeolocationContext
         }
 
         // Get visitor coordinates from GeoIP
-        $location = $this->getGeoLocationService()->getLocationForIp($clientIp);
+        $service = $this->getGeoLocationService();
+        if ($service === null) {
+            return $this->storeInSession($this->invert(false));
+        }
+
+        $location = $service->getLocationForIp($clientIp);
 
         if ($location === null || !$location->hasCoordinates()) {
             return $this->storeInSession($this->invert(false));

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -19,6 +19,9 @@ services:
       $databasePath: '%env(GEOIP_DATABASE_PATH)%'
 
   # GeoLocation Service with configurable proxy header trust
+  # Public: true allows context types to retrieve service from container
+  # when instantiated by the contexts extension's Container class
   Netresearch\ContextsGeolocation\Service\GeoLocationService:
+    public: true
     arguments:
       $trustProxyHeaders: '%env(bool:GEOIP_TRUST_PROXY_HEADERS)%'

--- a/Tests/Functional/Context/Type/ContinentContextTest.php
+++ b/Tests/Functional/Context/Type/ContinentContextTest.php
@@ -82,9 +82,10 @@ final class ContinentContextTest extends FunctionalTestCase
         $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
+        // Use initAll() to load all contexts without matching filter
         Container::get()
             ->setRequest($request)
-            ->initMatching();
+            ->initAll();
 
         // UID 5 is "Europe Continent Context" from fixture
         $context = Container::get()->find(5);
@@ -104,9 +105,10 @@ final class ContinentContextTest extends FunctionalTestCase
         $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
+        // Use initAll() to load all contexts without matching filter
         Container::get()
             ->setRequest($request)
-            ->initMatching();
+            ->initAll();
 
         $context = Container::get()->find('europe');
 
@@ -123,9 +125,10 @@ final class ContinentContextTest extends FunctionalTestCase
         $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
+        // Use initAll() to load all contexts without matching filter
         Container::get()
             ->setRequest($request)
-            ->initMatching();
+            ->initAll();
 
         $context = Container::get()->find(5);
 

--- a/Tests/Functional/Context/Type/ContinentContextTest.php
+++ b/Tests/Functional/Context/Type/ContinentContextTest.php
@@ -18,6 +18,7 @@ use Netresearch\ContextsGeolocation\Dto\GeoLocation;
 use Netresearch\ContextsGeolocation\Service\GeoLocationService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
@@ -78,11 +79,7 @@ final class ContinentContextTest extends FunctionalTestCase
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
 
-        $request = new ServerRequest(
-            uri: 'http://localhost/',
-            method: 'GET',
-            serverParams: ['REMOTE_ADDR' => '8.8.8.8'],
-        );
+        $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         Container::get()
@@ -104,11 +101,7 @@ final class ContinentContextTest extends FunctionalTestCase
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
 
-        $request = new ServerRequest(
-            uri: 'http://localhost/',
-            method: 'GET',
-            serverParams: ['REMOTE_ADDR' => '8.8.8.8'],
-        );
+        $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         Container::get()
@@ -127,11 +120,7 @@ final class ContinentContextTest extends FunctionalTestCase
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
 
-        $request = new ServerRequest(
-            uri: 'http://localhost/',
-            method: 'GET',
-            serverParams: ['REMOTE_ADDR' => '8.8.8.8'],
-        );
+        $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         Container::get()
@@ -173,11 +162,7 @@ final class ContinentContextTest extends FunctionalTestCase
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
 
-        $request = new ServerRequest(
-            uri: 'http://localhost/',
-            method: 'GET',
-            serverParams: ['REMOTE_ADDR' => '8.8.8.8'],
-        );
+        $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         self::assertTrue(
@@ -215,11 +200,7 @@ final class ContinentContextTest extends FunctionalTestCase
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
 
-        $request = new ServerRequest(
-            uri: 'http://localhost/',
-            method: 'GET',
-            serverParams: ['REMOTE_ADDR' => '8.8.8.8'],
-        );
+        $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         self::assertFalse(
@@ -257,11 +238,7 @@ final class ContinentContextTest extends FunctionalTestCase
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
 
-        $request = new ServerRequest(
-            uri: 'http://localhost/',
-            method: 'GET',
-            serverParams: ['REMOTE_ADDR' => '8.8.8.8'],
-        );
+        $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         self::assertTrue(
@@ -298,16 +275,28 @@ final class ContinentContextTest extends FunctionalTestCase
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REMOTE_ADDR'] = '10.0.0.1'; // Private IP
 
-        $request = new ServerRequest(
-            uri: 'http://localhost/',
-            method: 'GET',
-            serverParams: ['REMOTE_ADDR' => '10.0.0.1'],
-        );
+        $request = $this->createFrontendRequest('10.0.0.1');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         self::assertFalse(
             $context->match(),
             'Continent context should not match for private IP addresses',
         );
+    }
+
+    /**
+     * Create a ServerRequest configured for frontend mode.
+     *
+     * @param array<string, string> $serverParams
+     */
+    protected function createFrontendRequest(string $remoteAddr = '8.8.8.8', array $serverParams = []): ServerRequest
+    {
+        $serverParams['REMOTE_ADDR'] = $remoteAddr;
+
+        return (new ServerRequest(
+            uri: 'http://localhost/',
+            method: 'GET',
+            serverParams: $serverParams,
+        ))->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_FE);
     }
 }

--- a/Tests/Functional/Context/Type/CountryContextTest.php
+++ b/Tests/Functional/Context/Type/CountryContextTest.php
@@ -18,6 +18,7 @@ use Netresearch\ContextsGeolocation\Dto\GeoLocation;
 use Netresearch\ContextsGeolocation\Service\GeoLocationService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
@@ -78,11 +79,7 @@ final class CountryContextTest extends FunctionalTestCase
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
 
-        $request = new ServerRequest(
-            uri: 'http://localhost/',
-            method: 'GET',
-            serverParams: ['REMOTE_ADDR' => '8.8.8.8'],
-        );
+        $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         Container::get()
@@ -104,11 +101,7 @@ final class CountryContextTest extends FunctionalTestCase
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
 
-        $request = new ServerRequest(
-            uri: 'http://localhost/',
-            method: 'GET',
-            serverParams: ['REMOTE_ADDR' => '8.8.8.8'],
-        );
+        $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         Container::get()
@@ -127,11 +120,7 @@ final class CountryContextTest extends FunctionalTestCase
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
 
-        $request = new ServerRequest(
-            uri: 'http://localhost/',
-            method: 'GET',
-            serverParams: ['REMOTE_ADDR' => '8.8.8.8'],
-        );
+        $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         Container::get()
@@ -158,11 +147,7 @@ final class CountryContextTest extends FunctionalTestCase
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
 
-        $request = new ServerRequest(
-            uri: 'http://localhost/',
-            method: 'GET',
-            serverParams: ['REMOTE_ADDR' => '8.8.8.8'],
-        );
+        $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         Container::get()
@@ -181,11 +166,7 @@ final class CountryContextTest extends FunctionalTestCase
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
 
-        $request = new ServerRequest(
-            uri: 'http://localhost/',
-            method: 'GET',
-            serverParams: ['REMOTE_ADDR' => '8.8.8.8'],
-        );
+        $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         Container::get()
@@ -228,11 +209,7 @@ final class CountryContextTest extends FunctionalTestCase
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
 
-        $request = new ServerRequest(
-            uri: 'http://localhost/',
-            method: 'GET',
-            serverParams: ['REMOTE_ADDR' => '8.8.8.8'],
-        );
+        $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         self::assertTrue(
@@ -271,11 +248,7 @@ final class CountryContextTest extends FunctionalTestCase
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
 
-        $request = new ServerRequest(
-            uri: 'http://localhost/',
-            method: 'GET',
-            serverParams: ['REMOTE_ADDR' => '8.8.8.8'],
-        );
+        $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         self::assertFalse(
@@ -314,11 +287,7 @@ final class CountryContextTest extends FunctionalTestCase
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
 
-        $request = new ServerRequest(
-            uri: 'http://localhost/',
-            method: 'GET',
-            serverParams: ['REMOTE_ADDR' => '8.8.8.8'],
-        );
+        $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         // Normal match would be true (GB in GB), but inverted should be false
@@ -358,11 +327,7 @@ final class CountryContextTest extends FunctionalTestCase
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
 
-        $request = new ServerRequest(
-            uri: 'http://localhost/',
-            method: 'GET',
-            serverParams: ['REMOTE_ADDR' => '8.8.8.8'],
-        );
+        $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         self::assertTrue(
@@ -399,16 +364,28 @@ final class CountryContextTest extends FunctionalTestCase
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REMOTE_ADDR'] = '192.168.1.1'; // Private IP
 
-        $request = new ServerRequest(
-            uri: 'http://localhost/',
-            method: 'GET',
-            serverParams: ['REMOTE_ADDR' => '192.168.1.1'],
-        );
+        $request = $this->createFrontendRequest('192.168.1.1');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         self::assertFalse(
             $context->match(),
             'Country context should not match for private IP addresses',
         );
+    }
+
+    /**
+     * Create a ServerRequest configured for frontend mode.
+     *
+     * @param array<string, string> $serverParams
+     */
+    protected function createFrontendRequest(string $remoteAddr = '8.8.8.8', array $serverParams = []): ServerRequest
+    {
+        $serverParams['REMOTE_ADDR'] = $remoteAddr;
+
+        return (new ServerRequest(
+            uri: 'http://localhost/',
+            method: 'GET',
+            serverParams: $serverParams,
+        ))->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_FE);
     }
 }

--- a/Tests/Functional/Context/Type/CountryContextTest.php
+++ b/Tests/Functional/Context/Type/CountryContextTest.php
@@ -82,9 +82,11 @@ final class CountryContextTest extends FunctionalTestCase
         $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
+        // Use initAll() to load all contexts without matching filter
+        // initMatching() would filter out contexts that return false from match()
         Container::get()
             ->setRequest($request)
-            ->initMatching();
+            ->initAll();
 
         // UID 1 is "Germany Country Context" from fixture
         $context = Container::get()->find(1);
@@ -104,9 +106,10 @@ final class CountryContextTest extends FunctionalTestCase
         $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
+        // Use initAll() to load all contexts without matching filter
         Container::get()
             ->setRequest($request)
-            ->initMatching();
+            ->initAll();
 
         $context = Container::get()->find('germany');
 
@@ -123,9 +126,10 @@ final class CountryContextTest extends FunctionalTestCase
         $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
+        // Use initAll() to load all contexts without matching filter
         Container::get()
             ->setRequest($request)
-            ->initMatching();
+            ->initAll();
 
         // Check that multiple contexts are loaded from fixtures
         $germany = Container::get()->find('germany');
@@ -150,9 +154,10 @@ final class CountryContextTest extends FunctionalTestCase
         $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
+        // Use initAll() to load all contexts without matching filter
         Container::get()
             ->setRequest($request)
-            ->initMatching();
+            ->initAll();
 
         // UID 4 is disabled in fixture
         $context = Container::get()->find(4);
@@ -169,9 +174,10 @@ final class CountryContextTest extends FunctionalTestCase
         $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
+        // Use initAll() to load all contexts without matching filter
         Container::get()
             ->setRequest($request)
-            ->initMatching();
+            ->initAll();
 
         $context = Container::get()->find(1);
 

--- a/Tests/Functional/Context/Type/DistanceContextTest.php
+++ b/Tests/Functional/Context/Type/DistanceContextTest.php
@@ -18,6 +18,7 @@ use Netresearch\ContextsGeolocation\Dto\GeoLocation;
 use Netresearch\ContextsGeolocation\Service\GeoLocationService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
@@ -78,11 +79,7 @@ final class DistanceContextTest extends FunctionalTestCase
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
 
-        $request = new ServerRequest(
-            uri: 'http://localhost/',
-            method: 'GET',
-            serverParams: ['REMOTE_ADDR' => '8.8.8.8'],
-        );
+        $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         Container::get()
@@ -104,11 +101,7 @@ final class DistanceContextTest extends FunctionalTestCase
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
 
-        $request = new ServerRequest(
-            uri: 'http://localhost/',
-            method: 'GET',
-            serverParams: ['REMOTE_ADDR' => '8.8.8.8'],
-        );
+        $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         Container::get()
@@ -127,11 +120,7 @@ final class DistanceContextTest extends FunctionalTestCase
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
 
-        $request = new ServerRequest(
-            uri: 'http://localhost/',
-            method: 'GET',
-            serverParams: ['REMOTE_ADDR' => '8.8.8.8'],
-        );
+        $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         Container::get()
@@ -179,11 +168,7 @@ final class DistanceContextTest extends FunctionalTestCase
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
 
-        $request = new ServerRequest(
-            uri: 'http://localhost/',
-            method: 'GET',
-            serverParams: ['REMOTE_ADDR' => '8.8.8.8'],
-        );
+        $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         self::assertTrue(
@@ -227,11 +212,7 @@ final class DistanceContextTest extends FunctionalTestCase
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
 
-        $request = new ServerRequest(
-            uri: 'http://localhost/',
-            method: 'GET',
-            serverParams: ['REMOTE_ADDR' => '8.8.8.8'],
-        );
+        $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         self::assertFalse(
@@ -274,11 +255,7 @@ final class DistanceContextTest extends FunctionalTestCase
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
 
-        $request = new ServerRequest(
-            uri: 'http://localhost/',
-            method: 'GET',
-            serverParams: ['REMOTE_ADDR' => '8.8.8.8'],
-        );
+        $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         self::assertTrue(
@@ -315,11 +292,7 @@ final class DistanceContextTest extends FunctionalTestCase
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REMOTE_ADDR'] = '172.16.0.1'; // Private IP
 
-        $request = new ServerRequest(
-            uri: 'http://localhost/',
-            method: 'GET',
-            serverParams: ['REMOTE_ADDR' => '172.16.0.1'],
-        );
+        $request = $this->createFrontendRequest('172.16.0.1');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         self::assertFalse(
@@ -360,11 +333,7 @@ final class DistanceContextTest extends FunctionalTestCase
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
 
-        $request = new ServerRequest(
-            uri: 'http://localhost/',
-            method: 'GET',
-            serverParams: ['REMOTE_ADDR' => '8.8.8.8'],
-        );
+        $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         self::assertFalse(
@@ -402,11 +371,7 @@ final class DistanceContextTest extends FunctionalTestCase
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
 
-        $request = new ServerRequest(
-            uri: 'http://localhost/',
-            method: 'GET',
-            serverParams: ['REMOTE_ADDR' => '8.8.8.8'],
-        );
+        $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         self::assertFalse(
@@ -459,5 +424,21 @@ final class DistanceContextTest extends FunctionalTestCase
         );
 
         self::assertEqualsWithDelta(0.0, $samePoint, 0.001);
+    }
+
+    /**
+     * Create a ServerRequest configured for frontend mode.
+     *
+     * @param array<string, string> $serverParams
+     */
+    protected function createFrontendRequest(string $remoteAddr = '8.8.8.8', array $serverParams = []): ServerRequest
+    {
+        $serverParams['REMOTE_ADDR'] = $remoteAddr;
+
+        return (new ServerRequest(
+            uri: 'http://localhost/',
+            method: 'GET',
+            serverParams: $serverParams,
+        ))->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_FE);
     }
 }

--- a/Tests/Functional/Context/Type/DistanceContextTest.php
+++ b/Tests/Functional/Context/Type/DistanceContextTest.php
@@ -82,9 +82,10 @@ final class DistanceContextTest extends FunctionalTestCase
         $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
+        // Use initAll() to load all contexts without matching filter
         Container::get()
             ->setRequest($request)
-            ->initMatching();
+            ->initAll();
 
         // UID 7 is "Leipzig Distance Context" from fixture
         $context = Container::get()->find(7);
@@ -104,9 +105,10 @@ final class DistanceContextTest extends FunctionalTestCase
         $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
+        // Use initAll() to load all contexts without matching filter
         Container::get()
             ->setRequest($request)
-            ->initMatching();
+            ->initAll();
 
         $context = Container::get()->find('leipzig');
 
@@ -123,9 +125,10 @@ final class DistanceContextTest extends FunctionalTestCase
         $request = $this->createFrontendRequest('8.8.8.8');
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
+        // Use initAll() to load all contexts without matching filter
         Container::get()
             ->setRequest($request)
-            ->initMatching();
+            ->initAll();
 
         $context = Container::get()->find(7);
 
@@ -404,7 +407,7 @@ final class DistanceContextTest extends FunctionalTestCase
         $context = new DistanceContext($row, $service);
 
         // Test known distances
-        // Leipzig to Berlin: approximately 165km
+        // Leipzig to Berlin: approximately 149km (verified with haversine formula)
         $leipzigToBerlin = $context->calculateHaversineDistance(
             51.3397,
             12.3731,
@@ -412,8 +415,8 @@ final class DistanceContextTest extends FunctionalTestCase
             13.405,
         );
 
-        self::assertGreaterThan(160.0, $leipzigToBerlin);
-        self::assertLessThan(170.0, $leipzigToBerlin);
+        self::assertGreaterThan(145.0, $leipzigToBerlin);
+        self::assertLessThan(155.0, $leipzigToBerlin);
 
         // Same point should be 0km
         $samePoint = $context->calculateHaversineDistance(

--- a/fractor.php
+++ b/fractor.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Fractor configuration for TYPO3 extension upgrade
+ *
+ * Handles non-PHP file migrations:
+ * - FlexForms (XML)
+ * - TypoScript
+ * - YAML (Services.yaml)
+ * - Fluid templates
+ *
+ * @see https://github.com/andreaswolf/fractor
+ */
+
+declare(strict_types=1);
+
+use a9f\Fractor\Configuration\FractorConfiguration;
+use a9f\Typo3Fractor\Set\Typo3LevelSetList;
+
+return FractorConfiguration::configure()
+    ->withPaths([
+        __DIR__ . '/Configuration',
+        __DIR__ . '/Resources',
+    ])
+    ->withSkip([
+        __DIR__ . '/.Build',
+        __DIR__ . '/vendor',
+    ])
+    ->withSets([
+        // TYPO3 v12 migrations for FlexForms, TypoScript, YAML, Fluid
+        // Note: Don't use UP_TO_TYPO3_13 if extension supports both ^12.4 || ^13.4
+        Typo3LevelSetList::UP_TO_TYPO3_12,
+    ]);

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This file is part of the package netresearch/contexts-geolocation.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\StaticCall\RemoveParentCallWithoutParentRector;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+use Rector\Set\ValueObject\LevelSetList;
+use Ssch\TYPO3Rector\Set\Typo3LevelSetList;
+use Ssch\TYPO3Rector\Set\Typo3SetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__ . '/Classes',
+        __DIR__ . '/Configuration',
+        __DIR__ . '/Tests',
+    ]);
+
+    $rectorConfig->skip([
+        __DIR__ . '/ext_emconf.php',
+        __DIR__ . '/.Build',
+        __DIR__ . '/vendor',
+    ]);
+
+    $rectorConfig->phpstanConfig(__DIR__ . '/Build/phpstan.neon');
+    $rectorConfig->importNames();
+    $rectorConfig->removeUnusedImports();
+
+    // Define what rule sets will be applied - upgrade to PHP 8.2 and TYPO3 v13
+    $rectorConfig->sets([
+        // PHP level upgrades
+        LevelSetList::UP_TO_PHP_82,
+
+        // TYPO3 v12 migrations only (extension supports ^12.4 || ^13.4)
+        // Note: Don't use UP_TO_TYPO3_13 as it introduces v13-only APIs
+        Typo3LevelSetList::UP_TO_TYPO3_12,
+
+        // TYPO3 code quality and general improvements
+        Typo3SetList::CODE_QUALITY,
+        Typo3SetList::GENERAL,
+    ]);
+
+    // Skip some rules that may cause issues or require manual review
+    $rectorConfig->skip([
+        // Skip constructor promotion - keep explicit property declarations for clarity
+        ClassPropertyAssignToConstructorPromotionRector::class,
+
+        // Skip removing parent calls - may be needed for TYPO3 hooks
+        RemoveParentCallWithoutParentRector::class,
+    ]);
+};


### PR DESCRIPTION
## Summary

- Fix functional tests failing with `RuntimeException: No valid attribute "applicationType" found in request object`
- Remove saschaegerer/phpstan-typo3 dependency (incompatible with TYPO3 12.4 + PHPStan 2.x)
- Fix IPv6 test using RFC 3849 reserved address (replaced with Google DNS)
- Fix PHPat architecture test interface exclusion
- Align SBOM action with base contexts extension
- Add PHP 8.2/8.5 support to CI matrix
- Update AGENTS.md to reflect current state
- Bump various GitHub Actions

## Test plan

- [ ] CI passes on all matrix combinations
- [ ] Functional tests no longer fail with ApplicationType error