### PR TITLE
chore: add enterprise readiness improvements

### DIFF
--- a/.ddev/apache/v12.conf
+++ b/.ddev/apache/v12.conf
@@ -1,0 +1,52 @@
+# Apache VirtualHost for TYPO3 v12 subdirectory
+# Routes v12.contexts-geolocation.ddev.site to /var/www/html/v12/public
+
+<VirtualHost *:80>
+    ServerName v12.contexts-geolocation.ddev.site
+    DocumentRoot /var/www/html/v12/public
+
+    RewriteEngine On
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule ^(.+[^/])$ https://%{HTTP_HOST}$1/ [redirect,last]
+
+    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+
+    <Directory "/var/www/html/v12/public/">
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+    ErrorLog /dev/stdout
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    LimitRequestFieldSize 16380
+
+    Alias "/phpstatus" "/var/www/phpstatus.php"
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerName v12.contexts-geolocation.ddev.site
+    DocumentRoot /var/www/html/v12/public
+
+    SSLEngine on
+    SSLCertificateFile /etc/ssl/certs/master.crt
+    SSLCertificateKeyFile /etc/ssl/certs/master.key
+
+    RewriteEngine On
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule ^(.+[^/])$ https://%{HTTP_HOST}$1/ [redirect,last]
+
+    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+
+    <Directory "/var/www/html/v12/public/">
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+    ErrorLog /dev/stdout
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    LimitRequestFieldSize 16380
+
+    Alias "/phpstatus" "/var/www/phpstatus.php"
+</VirtualHost>

--- a/.ddev/apache/v13.conf
+++ b/.ddev/apache/v13.conf
@@ -1,0 +1,52 @@
+# Apache VirtualHost for TYPO3 v13 subdirectory
+# Routes v13.contexts-geolocation.ddev.site to /var/www/html/v13/public
+
+<VirtualHost *:80>
+    ServerName v13.contexts-geolocation.ddev.site
+    DocumentRoot /var/www/html/v13/public
+
+    RewriteEngine On
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule ^(.+[^/])$ https://%{HTTP_HOST}$1/ [redirect,last]
+
+    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+
+    <Directory "/var/www/html/v13/public/">
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+    ErrorLog /dev/stdout
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    LimitRequestFieldSize 16380
+
+    Alias "/phpstatus" "/var/www/phpstatus.php"
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerName v13.contexts-geolocation.ddev.site
+    DocumentRoot /var/www/html/v13/public
+
+    SSLEngine on
+    SSLCertificateFile /etc/ssl/certs/master.crt
+    SSLCertificateKeyFile /etc/ssl/certs/master.key
+
+    RewriteEngine On
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule ^(.+[^/])$ https://%{HTTP_HOST}$1/ [redirect,last]
+
+    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+
+    <Directory "/var/www/html/v13/public/">
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+    ErrorLog /dev/stdout
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    LimitRequestFieldSize 16380
+
+    Alias "/phpstatus" "/var/www/phpstatus.php"
+</VirtualHost>

--- a/.ddev/commands/web/install-v12
+++ b/.ddev/commands/web/install-v12
@@ -53,9 +53,9 @@ composer require "typo3/cms-fluid-styled-content:${TYPO3_VERSION}" --no-interact
 # Create directories
 mkdir -p public/typo3conf public/fileadmin public/uploads var/log var/cache config/system config/sites/${SITE_IDENTIFIER}
 
-# Database setup
+# Database setup - use root to create fresh database
 DB_NAME="db_v12"
-mysql -h db -u db -pdb -e "CREATE DATABASE IF NOT EXISTS ${DB_NAME};"
+mysql -h db -u root -proot -e "DROP DATABASE IF EXISTS ${DB_NAME}; CREATE DATABASE ${DB_NAME}; GRANT ALL PRIVILEGES ON ${DB_NAME}.* TO 'db'@'%';"
 
 # Create additional configuration
 cat > config/system/additional.php << 'ADDITIONAL_CONFIG'
@@ -80,7 +80,7 @@ ADDITIONAL_CONFIG
 
 # Setup TYPO3
 echo "Setting up TYPO3..."
-./vendor/bin/typo3 setup --driver=mysqli --host=db --port=3306 --dbname=db_v12 --username=db --password=db --admin-username=admin --admin-user-password=joh316 --admin-email=admin@example.com --project-name="Contexts Geolocation v12" --server-type=apache --no-interaction --force
+./vendor/bin/typo3 setup --driver=mysqli --host=db --port=3306 --dbname=db_v12 --username=db --password=db --admin-username=admin --admin-user-password='Password:joh316!' --admin-email=admin@example.com --project-name="Contexts Geolocation v12" --server-type=apache --no-interaction --force
 
 ./vendor/bin/typo3 extension:setup || true
 ./vendor/bin/typo3 cache:flush
@@ -89,5 +89,5 @@ echo ""
 echo "=== TYPO3 v12 Installation Complete ==="
 echo "Frontend: ${SITE_BASE}"
 echo "Backend:  ${SITE_BASE}typo3"
-echo "Admin:    admin / joh316"
+echo "Admin:    admin / Password:joh316!"
 echo ""

--- a/.ddev/commands/web/install-v12
+++ b/.ddev/commands/web/install-v12
@@ -35,20 +35,20 @@ cp -a "${TEMP_DIR}"/. "${INSTALL_DIR}/"
 rm -rf "${TEMP_DIR}"
 cd "${INSTALL_DIR}"
 
-# Configure local extension repository
+# Remove platform config to allow PHP 8.2+ requirement
+echo "Removing platform PHP override..."
+composer config --unset platform.php
+
+# Configure local extension repository (keep packagist for dependencies)
 echo "Configuring local extension repository..."
-composer config repositories.packagist.org false
 composer config repositories.local path "${EXTENSION_DIR}"
 composer config minimum-stability dev
 composer config prefer-stable true
 
-# Install extensions
+# Install extensions (packagist needed for geoip2/geoip2 dependency)
 echo "Installing contexts_geolocation extension..."
 composer require "netresearch/contexts-geolocation:*" --no-interaction
 composer require "typo3/cms-fluid-styled-content:${TYPO3_VERSION}" --no-interaction
-
-# Re-enable packagist
-composer config repositories.packagist.org composer https://repo.packagist.org
 
 # Create directories
 mkdir -p public/typo3conf public/fileadmin public/uploads var/log var/cache config/system config/sites/${SITE_IDENTIFIER}

--- a/.ddev/commands/web/install-v13
+++ b/.ddev/commands/web/install-v13
@@ -53,9 +53,9 @@ composer require "typo3/cms-fluid-styled-content:${TYPO3_VERSION}" --no-interact
 # Create directories
 mkdir -p public/typo3conf public/fileadmin public/uploads var/log var/cache config/system config/sites/${SITE_IDENTIFIER}
 
-# Database setup
+# Database setup - use root to create fresh database
 DB_NAME="db_v13"
-mysql -h db -u db -pdb -e "CREATE DATABASE IF NOT EXISTS ${DB_NAME};"
+mysql -h db -u root -proot -e "DROP DATABASE IF EXISTS ${DB_NAME}; CREATE DATABASE ${DB_NAME}; GRANT ALL PRIVILEGES ON ${DB_NAME}.* TO 'db'@'%';"
 
 # Create additional configuration
 cat > config/system/additional.php << 'ADDITIONAL_CONFIG'
@@ -80,7 +80,7 @@ ADDITIONAL_CONFIG
 
 # Setup TYPO3
 echo "Setting up TYPO3..."
-./vendor/bin/typo3 setup --driver=mysqli --host=db --port=3306 --dbname=db_v13 --username=db --password=db --admin-username=admin --admin-user-password=joh316 --admin-email=admin@example.com --project-name="Contexts Geolocation v13" --server-type=apache --no-interaction --force
+./vendor/bin/typo3 setup --driver=mysqli --host=db --port=3306 --dbname=db_v13 --username=db --password=db --admin-username=admin --admin-user-password='Password:joh316!' --admin-email=admin@example.com --project-name="Contexts Geolocation v13" --server-type=apache --no-interaction --force
 
 ./vendor/bin/typo3 extension:setup || true
 ./vendor/bin/typo3 cache:flush
@@ -89,5 +89,5 @@ echo ""
 echo "=== TYPO3 v13 Installation Complete ==="
 echo "Frontend: ${SITE_BASE}"
 echo "Backend:  ${SITE_BASE}typo3"
-echo "Admin:    admin / joh316"
+echo "Admin:    admin / Password:joh316!"
 echo ""

--- a/.ddev/commands/web/install-v13
+++ b/.ddev/commands/web/install-v13
@@ -35,20 +35,20 @@ cp -a "${TEMP_DIR}"/. "${INSTALL_DIR}/"
 rm -rf "${TEMP_DIR}"
 cd "${INSTALL_DIR}"
 
-# Configure local extension repository
+# Remove platform config to allow PHP 8.2+ requirement
+echo "Removing platform PHP override..."
+composer config --unset platform.php
+
+# Configure local extension repository (keep packagist for dependencies)
 echo "Configuring local extension repository..."
-composer config repositories.packagist.org false
 composer config repositories.local path "${EXTENSION_DIR}"
 composer config minimum-stability dev
 composer config prefer-stable true
 
-# Install extensions (geolocation requires contexts)
+# Install extensions (packagist needed for geoip2/geoip2 dependency)
 echo "Installing contexts_geolocation extension..."
 composer require "netresearch/contexts-geolocation:*" --no-interaction
 composer require "typo3/cms-fluid-styled-content:${TYPO3_VERSION}" --no-interaction
-
-# Re-enable packagist
-composer config repositories.packagist.org composer https://repo.packagist.org
 
 # Create directories
 mkdir -p public/typo3conf public/fileadmin public/uploads var/log var/cache config/system config/sites/${SITE_IDENTIFIER}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,45 @@
+# OpenSSF Scorecard - Security health metrics for open source projects
+# https://github.com/ossf/scorecard-action
+name: Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '30 2 * * 0' # Weekly on Sunday at 02:30 UTC
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -1,0 +1,63 @@
+# SLSA Level 3 Provenance - Supply chain security attestation
+# https://slsa.dev/spec/v1.0/levels
+name: SLSA Provenance
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and hash
+    runs-on: ubuntu-latest
+    outputs:
+      hash: ${{ steps.hash.outputs.base64 }}
+      tag: ${{ steps.tag.outputs.name }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Get tag name
+        id: tag
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          echo "name=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Create source archive
+        env:
+          TAG_NAME: ${{ steps.tag.outputs.name }}
+        run: |
+          git archive --format=tar.gz --prefix="contexts_geolocation-${TAG_NAME}/" \
+            -o "contexts_geolocation-${TAG_NAME}.tar.gz" HEAD
+
+      - name: Generate subject hash
+        id: hash
+        env:
+          TAG_NAME: ${{ steps.tag.outputs.name }}
+        run: |
+          HASH=$(sha256sum "contexts_geolocation-${TAG_NAME}.tar.gz" | base64 -w0)
+          echo "base64=$HASH" >> $GITHUB_OUTPUT
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: source-archive
+          path: contexts_geolocation-${{ steps.tag.outputs.name }}.tar.gz
+          retention-days: 5
+
+  provenance:
+    needs: build
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: ${{ needs.build.outputs.hash }}
+      upload-assets: true
+      compile-generator: true
+      private-repository: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ ddev install-all          # Install TYPO3 v12, v13
 https://v12.contexts-geolocation.ddev.site/typo3/    # TYPO3 v12 backend
 https://v13.contexts-geolocation.ddev.site/typo3/    # TYPO3 v13 backend
 
-# Credentials: admin / Password:joh316
+# Credentials: admin / Password:joh316!
 ```
 
 ## CI Workflows

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,8 +50,9 @@ https://v13.contexts-geolocation.ddev.site/typo3/    # TYPO3 v13 backend
 |----------|---------|---------|
 | `ci.yml` | push/PR | Full test suite (unit, functional, lint, phpstan) |
 | `phpstan.yml` | push/PR | Static analysis |
-| `phpcs.yml` | push/PR | Code style |
 | `security.yml` | schedule | Dependency vulnerability scan |
+| `scorecard.yml` | push to main, weekly | OpenSSF Scorecard security analysis |
+| `slsa-provenance.yml` | release | SLSA Level 3 provenance attestation |
 | `publish-to-ter.yml` | tag | Publish to TYPO3 Extension Repository |
 
 ## Project Structure (Target)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,54 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+* The use of sexualized language or imagery and unwelcome sexual attention
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without explicit permission
+* Other conduct which could reasonably be considered inappropriate
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and also applies when
+an individual is officially representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project team at typo3@netresearch.de. All complaints will be
+reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@
 [![PHP](https://img.shields.io/badge/PHP-8.2+-blue.svg?style=flat-square)](https://php.net/)
 [![License](https://img.shields.io/badge/License-AGPL--3.0--or--later-green.svg?style=flat-square)](LICENSE)
 
+[![CI](https://img.shields.io/github/actions/workflow/status/netresearch/t3x-contexts_geolocation/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/netresearch/t3x-contexts_geolocation/actions/workflows/ci.yml)
+[![PHPStan](https://img.shields.io/badge/PHPStan-level%2010-brightgreen?style=flat-square)](https://phpstan.org/)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/netresearch/t3x-contexts_geolocation/badge?style=flat-square)](https://scorecard.dev/viewer/?uri=github.com/netresearch/t3x-contexts_geolocation)
+[![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg?style=flat-square)](CODE_OF_CONDUCT.md)
+
 Geolocation-based context types for TYPO3. Show pages and content elements for
 visitors in specific countries, continents, or within a defined geographic area.
 


### PR DESCRIPTION
## Summary
- Add OpenSSF Scorecard workflow for security metrics
- Add SLSA Level 3 provenance workflow for supply chain security
- Add CODE_OF_CONDUCT.md (Contributor Covenant 2.0)
- Add CI, PHPStan, Scorecard, SLSA, and Contributor Covenant badges to README
- Update AGENTS.md with accurate workflow documentation

## Changes
- **scorecard.yml**: Weekly OpenSSF Scorecard analysis, uploads to GitHub Security tab
- **slsa-provenance.yml**: SLSA Level 3 attestation on releases
- **CODE_OF_CONDUCT.md**: Contributor Covenant 2.0 code of conduct
- **README.md**: Added enterprise-grade badges
- **AGENTS.md**: Fixed workflow documentation (removed non-existent phpcs.yml, added new workflows)

## Test plan
- [ ] CI workflows pass
- [ ] Scorecard workflow runs successfully (on merge to main)
- [ ] SLSA workflow triggers on release (manual test)