### PR TITLE
chore: add SPDX copyright and license headers

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * PHP-CS-Fixer configuration for TYPO3 extension.
  *

--- a/Build/Scripts/router.php
+++ b/Build/Scripts/router.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * Router script for PHP built-in server to handle TYPO3 rewrites
  *

--- a/Classes/Adapter/GeoIpAdapterInterface.php
+++ b/Classes/Adapter/GeoIpAdapterInterface.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\ContextsGeolocation\Adapter;

--- a/Classes/Adapter/MaxMindGeoIp2Adapter.php
+++ b/Classes/Adapter/MaxMindGeoIp2Adapter.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\ContextsGeolocation\Adapter;

--- a/Classes/Context/Type/AbstractGeolocationContext.php
+++ b/Classes/Context/Type/AbstractGeolocationContext.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * This file is part of the package netresearch/contexts-geolocation.
  *

--- a/Classes/Context/Type/ContinentContext.php
+++ b/Classes/Context/Type/ContinentContext.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * This file is part of the package netresearch/contexts-geolocation.
  *

--- a/Classes/Context/Type/CountryContext.php
+++ b/Classes/Context/Type/CountryContext.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * This file is part of the package netresearch/contexts-geolocation.
  *

--- a/Classes/Context/Type/DistanceContext.php
+++ b/Classes/Context/Type/DistanceContext.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * This file is part of the package netresearch/contexts-geolocation.
  *

--- a/Classes/Dto/GeoLocation.php
+++ b/Classes/Dto/GeoLocation.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\ContextsGeolocation\Dto;

--- a/Classes/Exception/GeoIpException.php
+++ b/Classes/Exception/GeoIpException.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\ContextsGeolocation\Exception;

--- a/Classes/Service/GeoLocationService.php
+++ b/Classes/Service/GeoLocationService.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\ContextsGeolocation\Service;

--- a/Configuration/TCA/Overrides/tx_contexts_contexts.php
+++ b/Configuration/TCA/Overrides/tx_contexts_contexts.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * This file is part of the package netresearch/contexts-geolocation.
  *

--- a/Tests/Architecture/LayerTest.php
+++ b/Tests/Architecture/LayerTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * This file is part of the package netresearch/contexts-geolocation.
  *

--- a/Tests/Functional/Context/Type/ContinentContextTest.php
+++ b/Tests/Functional/Context/Type/ContinentContextTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * This file is part of the package netresearch/contexts-geolocation.
  *

--- a/Tests/Functional/Context/Type/CountryContextTest.php
+++ b/Tests/Functional/Context/Type/CountryContextTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * This file is part of the package netresearch/contexts-geolocation.
  *

--- a/Tests/Functional/Context/Type/DistanceContextTest.php
+++ b/Tests/Functional/Context/Type/DistanceContextTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * This file is part of the package netresearch/contexts-geolocation.
  *

--- a/Tests/Unit/Adapter/MaxMindGeoIp2AdapterTest.php
+++ b/Tests/Unit/Adapter/MaxMindGeoIp2AdapterTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\ContextsGeolocation\Tests\Unit\Adapter;

--- a/Tests/Unit/Context/Type/ContinentContextTest.php
+++ b/Tests/Unit/Context/Type/ContinentContextTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\ContextsGeolocation\Tests\Unit\Context\Type;

--- a/Tests/Unit/Context/Type/CountryContextTest.php
+++ b/Tests/Unit/Context/Type/CountryContextTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\ContextsGeolocation\Tests\Unit\Context\Type;

--- a/Tests/Unit/Context/Type/DistanceContextTest.php
+++ b/Tests/Unit/Context/Type/DistanceContextTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\ContextsGeolocation\Tests\Unit\Context\Type;

--- a/Tests/Unit/Dto/GeoLocationTest.php
+++ b/Tests/Unit/Dto/GeoLocationTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\ContextsGeolocation\Tests\Unit\Dto;

--- a/Tests/Unit/Service/GeoLocationServiceTest.php
+++ b/Tests/Unit/Service/GeoLocationServiceTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace Netresearch\ContextsGeolocation\Tests\Unit\Service;

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 declare(strict_types=1);
 
 $EM_CONF[$_EXTKEY] = [

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 declare(strict_types=1);
 
 defined('TYPO3') or die();

--- a/fractor.php
+++ b/fractor.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * Fractor configuration for TYPO3 extension upgrade
  *

--- a/rector.php
+++ b/rector.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * This file is part of the package netresearch/contexts-geolocation.
  *


### PR DESCRIPTION
## Summary
- Add SPDX copyright and license headers to all PHP source files
- Supports OpenSSF Best Practices Gold badge criteria

## Test plan
- [ ] CI passes