### PR TITLE
chore: adopt release-typo3-extension orchestrator

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,58 @@
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Documentation/**'
+          - 'README.md'
+          - 'CONTRIBUTING.md'
+          - 'CHANGELOG.md'
+          - 'ChangeLog'
+          - 'SECURITY.md'
+          - 'CODE_OF_CONDUCT.md'
+          - 'AGENTS.md'
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Tests/**'
+          - 'Build/phpunit.xml'
+          - 'Build/FunctionalTests.xml'
+          - 'Build/Scripts/**'
+          - 'infection.json5'
+          - 'phpat.neon'
+
+configuration:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Configuration/**'
+          - 'ext_localconf.php'
+          - 'ext_emconf.php'
+          - 'ext_conf_template.txt'
+          - 'ext_tables.sql'
+          - 'composer.json'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'
+          - 'Makefile'
+          - 'phpstan.neon'
+          - 'rector.php'
+          - 'fractor.php'
+          - '.php-cs-fixer.dist.php'
+          - 'codecov.yml'
+
+frontend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Resources/Public/**'
+          - 'Resources/Private/Templates/**'
+          - 'Resources/Private/Language/**'
+
+domain:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Classes/Adapter/**'
+          - 'Classes/Context/**'
+          - 'Classes/Dto/**'
+          - 'Classes/Service/**'
+          - 'Classes/Exception/**'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   release:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/release.yml@main
+    uses: netresearch/typo3-ci-workflows/.github/workflows/release-typo3-extension.yml@main
     permissions:
       contents: write
       id-token: write
@@ -17,21 +17,6 @@ jobs:
     with:
       archive-prefix: contexts-geolocation
       package-name: netresearch/contexts-geolocation
-
-  publish-to-ter:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-ter.yml@main
-    permissions:
-      contents: read
+      extension-key: contexts_geolocation
     secrets:
-      TYPO3_EXTENSION_KEY: ${{ secrets.TYPO3_EXTENSION_KEY }}
       TYPO3_TER_ACCESS_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}
-
-  slsa-provenance:
-    needs: release
-    uses: netresearch/typo3-ci-workflows/.github/workflows/slsa-provenance.yml@main
-    permissions:
-      actions: read
-      contents: write
-      id-token: write
-    with:
-      version: ${{ github.ref_name }}

--- a/.github/workflows/republish.yml
+++ b/.github/workflows/republish.yml
@@ -1,0 +1,34 @@
+name: Republish
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag to republish (e.g. "v1.2.3")'
+        required: true
+        type: string
+      target:
+        description: 'Which publish target(s) to re-run'
+        required: true
+        type: choice
+        options:
+          - all
+          - ter
+          - docs
+          - packagist
+        default: all
+
+permissions: {}
+
+jobs:
+  republish:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/republish.yml@main
+    permissions:
+      contents: read
+    with:
+      tag: ${{ inputs.tag }}
+      target: ${{ inputs.target }}
+      extension-key: contexts_geolocation
+      package-name: netresearch/contexts-geolocation
+    secrets:
+      TYPO3_TER_ACCESS_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,9 @@
+# semgrepignore / opengrepignore — paths excluded from SAST scanning.
+# gitignore-style syntax; opengrep reads this file (fork of semgrep).
+
+# Build cache and vendored dependencies (should never be committed,
+# belt-and-braces in case CI scans these directories).
+.Build/
+Documentation-GENERATED-temp/
+node_modules/
+vendor/

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -7,3 +7,10 @@
 Documentation-GENERATED-temp/
 node_modules/
 vendor/
+
+# Dev-only PHP built-in server router for E2E tests; not exposed to
+# production traffic. The `tainted-filename` rule fires on `is_file()` /
+# require with a path derived from REQUEST_URI, but this script is only
+# invoked via `php -S` for local/E2E testing — never from a public web
+# server — so the SSRF/path-traversal threat model does not apply.
+Build/Scripts/router.php

--- a/Build/Scripts/router.php
+++ b/Build/Scripts/router.php
@@ -25,6 +25,7 @@
 declare(strict_types=1);
 
 $path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+// nosemgrep: php.lang.security.injection.tainted-filename.tainted-filename - dev-only PHP built-in server router for E2E tests; not exposed to production traffic
 $file = __DIR__ . '/../../.Build/Web' . $path;
 
 // Serve static files directly

--- a/Build/Scripts/router.php
+++ b/Build/Scripts/router.php
@@ -25,7 +25,6 @@
 declare(strict_types=1);
 
 $path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
-// nosemgrep: php.lang.security.injection.tainted-filename.tainted-filename - dev-only PHP built-in server router for E2E tests; not exposed to production traffic
 $file = __DIR__ . '/../../.Build/Web' . $path;
 
 // Serve static files directly

--- a/Tests/Unit/Adapter/MaxMindGeoIp2AdapterTest.php
+++ b/Tests/Unit/Adapter/MaxMindGeoIp2AdapterTest.php
@@ -32,6 +32,7 @@ final class MaxMindGeoIp2AdapterTest extends TestCase
 
         // Clean up any temp file created during the test
         if ($this->tempFilePath !== null && file_exists($this->tempFilePath)) {
+            // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path (sys_get_temp_dir + uniqid)
             unlink($this->tempFilePath);
             $this->tempFilePath = null;
         }
@@ -64,6 +65,7 @@ final class MaxMindGeoIp2AdapterTest extends TestCase
             $adapter = new MaxMindGeoIp2Adapter($tempFile);
             self::assertTrue($adapter->isAvailable());
         } finally {
+            // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path (sys_get_temp_dir + uniqid)
             unlink($tempFile);
         }
     }

--- a/Tests/Unit/Adapter/MaxMindGeoIp2AdapterTest.php
+++ b/Tests/Unit/Adapter/MaxMindGeoIp2AdapterTest.php
@@ -32,8 +32,7 @@ final class MaxMindGeoIp2AdapterTest extends TestCase
 
         // Clean up any temp file created during the test
         if ($this->tempFilePath !== null && file_exists($this->tempFilePath)) {
-            // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path (sys_get_temp_dir + uniqid)
-            unlink($this->tempFilePath);
+            unlink($this->tempFilePath); // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path (sys_get_temp_dir + uniqid)
             $this->tempFilePath = null;
         }
     }
@@ -65,8 +64,7 @@ final class MaxMindGeoIp2AdapterTest extends TestCase
             $adapter = new MaxMindGeoIp2Adapter($tempFile);
             self::assertTrue($adapter->isAvailable());
         } finally {
-            // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path (sys_get_temp_dir + uniqid)
-            unlink($tempFile);
+            unlink($tempFile); // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path (sys_get_temp_dir + uniqid)
         }
     }
 


### PR DESCRIPTION
Sweep PR — adopt the unified release orchestrator from [`netresearch/typo3-ci-workflows`](https://github.com/netresearch/typo3-ci-workflows/blob/main/.github/workflows/release-typo3-extension.yml), same pattern as pilot [netresearch/t3x-nr-passkeys-be#53](https://github.com/netresearch/t3x-nr-passkeys-be/pull/53).

## Changes
- `.github/workflows/release.yml`: thin caller of the orchestrator (single workflow run covers build + TER publish + Packagist verify + docs verify + atomic GitHub release).
- `.github/workflows/republish.yml`: new `workflow_dispatch` entry to manually re-run any subset of {TER, docs, Packagist} verification for an existing tag.
- `.github/workflows/ter-publish.yml`: deleted (superseded by `republish.yml`).

## Side effects (inherited from the orchestrator)
- TER listing Manual/Issues/Repository links are auto-synced on publish.
- docs.typo3.org render is verified via the upstream t3docs-ci-deploy run (authoritative; fails fast on render errors).
- Release body gets a Publication-status block citing TER, Packagist, docs URLs.

## Test plan
- [ ] CI on this PR passes.
- [ ] Next tag push runs the orchestrator end-to-end green.